### PR TITLE
Validate positive start values

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -122,9 +122,15 @@ function spawnConfetti(count) {
 function startGame() {
   goldStart  = Number(startGoldInput.value); // read inputs
   drawsTotal = Number(drawsInput.value);
-  // basic validation
-  if (!goldStart || !drawsTotal)
+  // basic validation: ensure positive numbers were entered
+  if (
+    !Number.isFinite(goldStart) ||
+    !Number.isFinite(drawsTotal) ||
+    goldStart <= 0 ||
+    drawsTotal <= 0
+  ) {
     return alert("Enter valid numbers!");
+  }
 
   goldRemaining = goldStart;
   drawIndex = 1;


### PR DESCRIPTION
## Summary
- Require positive numeric values for starting gold and total draws
- Added newline at end of script for clean formatting

## Testing
- `node --check docs/script.js`


------
https://chatgpt.com/codex/tasks/task_e_6895dfb153dc832fac36c0db1e1a7fb4